### PR TITLE
Add WEBUI_PORT, adjust HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN apk --update --no-cache add \
 ENV QBITTORRENT_HOME="/home/qbittorrent" \
   TZ="UTC" \
   PUID="1500" \
-  PGID="1500"
+  PGID="1500" \
+  WEBUI_PORT="8080"
 
 COPY entrypoint.sh /entrypoint.sh
 
@@ -89,4 +90,4 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/usr/bin/qbittorrent-nox" ]
 
 HEALTHCHECK --interval=10s --timeout=10s --start-period=20s \
-  CMD curl --fail http://127.0.0.1:8080/api/v2/app/version || exit 1
+  CMD curl --fail http://127.0.0.1:${WEBUI_PORT}/api/v2/app/version || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ General\UseRandomPort=false
 WebUI\Enabled=true
 WebUI\HTTPS\Enabled=false
 WebUI\Address=0.0.0.0
-WebUI\Port=8080
+WebUI\Port=${WEBUI_PORT}
 WebUI\LocalHostAuth=false
 WebUI\AlternativeUIEnabled=${ALT_WEBUI}
 WebUI\RootFolder=/data/webui
@@ -82,7 +82,7 @@ sed -i "s!Downloads\\\TempPathEnabled.*!Downloads\\\TempPathEnabled=true!g" /dat
 sed -i "s!Downloads\\\FinishedTorrentExportDir.*!Downloads\\\FinishedTorrentExportDir=/data/torrents!g" /data/config/qBittorrent.conf
 sed -i "s!WebUI\\\Enabled.*!WebUI\\\Enabled=true!g" /data/config/qBittorrent.conf
 sed -i "s!WebUI\\\Address.*!WebUI\\\Address=0\.0\.0\.0!g" /data/config/qBittorrent.conf
-sed -i "s!WebUI\\\Port.*!WebUI\\\Port=8080!g" /data/config/qBittorrent.conf
+sed -i "s!WebUI\\\Port.*!WebUI\\\Port=${WEBUI_PORT}!g" /data/config/qBittorrent.conf
 sed -i "s!WebUI\\\LocalHostAuth.*!WebUI\\\LocalHostAuth=false!g" /data/config/qBittorrent.conf
 sed -i "s!WebUI\\\RootFolder.*!WebUI\\\RootFolder=/data/webui!g" /data/config/qBittorrent.conf
 


### PR DESCRIPTION
WEBUI_PORT env can be used to define the port on which the WebUI will be used. At the same time the HEALTCHECK was adjusted to use the said env so it does not fail.